### PR TITLE
feat: add config subcommands

### DIFF
--- a/cmd/assign.go
+++ b/cmd/assign.go
@@ -65,16 +65,16 @@ Feeders not listed in the CSV are left unchanged.`,
 		assigned, unchanged, notFound, reset := 0, 0, 0, 0
 		for _, r := range results {
 			switch r.Status {
-			case "assigned":
+			case openpnp.StatusAssigned:
 				fmt.Printf("  ✓ %s: %s → %s\n", r.FeederName, r.OldPartID, r.PartID)
 				assigned++
-			case "unchanged":
+			case openpnp.StatusUnchanged:
 				fmt.Printf("  = %s: %s\n", r.FeederName, r.PartID)
 				unchanged++
-			case "not_found":
+			case openpnp.StatusNotFound:
 				fmt.Printf("  ? %s: not found in machine.xml\n", r.FeederName)
 				notFound++
-			case "reset":
+			case openpnp.StatusReset:
 				fmt.Printf("  ✗ %s: %s → %s\n", r.FeederName, r.OldPartID, r.PartID)
 				reset++
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"github.com/laenzlinger/openpnp-tools/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var configDirFlag string
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage OpenPnP configuration (backup, apply, pull, status)",
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.PersistentFlags().StringVar(&configDirFlag, "config-dir", config.DefaultConfigDir(),
+		"path to OpenPnP config directory")
+}

--- a/cmd/config_apply.go
+++ b/cmd/config_apply.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/laenzlinger/openpnp-tools/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var applyFromFlag string
+var applyNoBackupFlag bool
+
+var configApplyCmd = &cobra.Command{
+	Use:          "apply",
+	Short:        "Apply base config to ~/.openpnp2 (backs up first, OpenPnP must be closed)",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.CheckNotRunning(); err != nil {
+			return err
+		}
+
+		if !applyNoBackupFlag {
+			dir, err := config.Backup(configDirFlag)
+			if err != nil {
+				return fmt.Errorf("backup failed: %w", err)
+			}
+			fmt.Printf("  backup → %s\n", dir)
+		}
+
+		from := applyFromFlag
+		if from == "" {
+			from = "."
+		}
+		copied, err := config.CopyManagedFiles(from, configDirFlag)
+		if err != nil {
+			return err
+		}
+		for _, f := range copied {
+			fmt.Printf("  %s applied\n", f)
+		}
+		fmt.Println("Applied config repo → " + configDirFlag)
+		return nil
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configApplyCmd)
+	configApplyCmd.Flags().StringVar(&applyFromFlag, "from", "",
+		"source directory (default: current directory)")
+	configApplyCmd.Flags().BoolVar(&applyNoBackupFlag, "no-backup", false,
+		"skip backup before applying")
+}

--- a/cmd/config_backup.go
+++ b/cmd/config_backup.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/laenzlinger/openpnp-tools/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var configBackupCmd = &cobra.Command{
+	Use:          "backup",
+	Short:        "Backup ~/.openpnp2 config files (same format as OpenPnP)",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := config.Backup(configDirFlag)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("  backup → %s\n", dir)
+		return nil
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configBackupCmd)
+}

--- a/cmd/config_pull.go
+++ b/cmd/config_pull.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/laenzlinger/openpnp-tools/internal/config"
+	"github.com/laenzlinger/openpnp-tools/internal/openpnp"
+	"github.com/spf13/cobra"
+)
+
+var pullToFlag string
+var pullNoResetFlag bool
+var pullDummyPartFlag string
+
+var configPullCmd = &cobra.Command{
+	Use:          "pull",
+	Short:        "Pull live ~/.openpnp2 config into repo directory (OpenPnP must be closed)",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.CheckNotRunning(); err != nil {
+			return err
+		}
+
+		to := pullToFlag
+		if to == "" {
+			to = "."
+		}
+
+		copied, err := config.CopyManagedFiles(configDirFlag, to)
+		if err != nil {
+			return err
+		}
+		for _, f := range copied {
+			fmt.Printf("  %s synced\n", f)
+		}
+
+		if !pullNoResetFlag {
+			machPath := filepath.Join(to, "machine.xml")
+			results, err := openpnp.ResetFeeders(machPath, pullDummyPartFlag)
+			if err != nil {
+				return fmt.Errorf("resetting feeders: %w", err)
+			}
+			resetCount := 0
+			for _, r := range results {
+				if r.Status == openpnp.StatusReset {
+					resetCount++
+				}
+			}
+			fmt.Printf("  %d feeders reset\n", resetCount)
+		}
+
+		fmt.Println("Pulled " + configDirFlag + " → config repo (feeders reset)")
+		return nil
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configPullCmd)
+	configPullCmd.Flags().StringVar(&pullToFlag, "to", "",
+		"destination directory (default: current directory)")
+	configPullCmd.Flags().BoolVar(&pullNoResetFlag, "no-reset", false,
+		"skip reset-feeders after pulling")
+	configPullCmd.Flags().StringVar(&pullDummyPartFlag, "dummy-part", "CALIBRATION-DUMMY",
+		"part-id to use for reset feeders")
+}

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/laenzlinger/openpnp-tools/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var statusRepoFlag string
+
+var configStatusCmd = &cobra.Command{
+	Use:           "status",
+	Short:         "Show OpenPnP process status and config drift",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		running := config.IsOpenPnPRunning()
+		if running {
+			fmt.Println("OpenPnP: RUNNING")
+		} else {
+			fmt.Println("OpenPnP: STOPPED")
+		}
+
+		repo := statusRepoFlag
+		if repo == "" {
+			repo = "."
+		}
+		results, err := config.CompareFiles(configDirFlag, repo)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Config drift:")
+		for _, r := range results {
+			fmt.Printf("  %-25s %s\n", r.Name, r.Status)
+		}
+
+		if running {
+			return fmt.Errorf("OpenPnP is running")
+		}
+		return nil
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configStatusCmd)
+	configStatusCmd.Flags().StringVar(&statusRepoFlag, "repo", "",
+		"repo directory to compare against (default: current directory)")
+}

--- a/cmd/reset_feeders.go
+++ b/cmd/reset_feeders.go
@@ -35,10 +35,10 @@ Workflow:
 		resetCount, unchanged := 0, 0
 		for _, r := range results {
 			switch r.Status {
-			case "reset":
+			case openpnp.StatusReset:
 				fmt.Printf("  ✗ %s: %s → %s\n", r.FeederName, r.OldPartID, resetDummyPartFlag)
 				resetCount++
-			case "unchanged":
+			case openpnp.StatusUnchanged:
 				fmt.Printf("  = %s\n", r.FeederName)
 				unchanged++
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ManagedFiles are the config files we copy during pull/apply.
+var ManagedFiles = []string{
+	"machine.xml",
+	"parts.xml",
+	"packages.xml",
+	"vision-settings.xml",
+}
+
+// backupFiles are all XMLs OpenPnP backs up (superset of ManagedFiles).
+var backupFiles = []string{
+	"machine.xml",
+	"parts.xml",
+	"packages.xml",
+	"vision-settings.xml",
+	"boards.xml",
+	"panels.xml",
+}
+
+const (
+	backupSubdir = "backups"
+	// OpenPnP's timestamp format: 2024-10-18_18.15.12
+	timestampFmt = "2006-01-02_15.04.05"
+)
+
+// DefaultConfigDir returns ~/.openpnp2.
+func DefaultConfigDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".openpnp2")
+}
+
+// IsOpenPnPRunning checks whether an OpenPnP process is running.
+func IsOpenPnPRunning() bool {
+	if runtime.GOOS == "windows" {
+		out, err := exec.Command("tasklist", "/FI", "IMAGENAME eq OpenPnP*").Output()
+		return err == nil && strings.Contains(string(out), "OpenPnP")
+	}
+	err := exec.Command("pgrep", "-f", "[Oo]pen[Pp]np").Run()
+	return err == nil
+}
+
+// CheckNotRunning returns an error if OpenPnP is running.
+func CheckNotRunning() error {
+	if IsOpenPnPRunning() {
+		return fmt.Errorf("OpenPnP is running — close it first")
+	}
+	return nil
+}
+
+// Backup copies all XML config files from configDir into configDir/backups/<timestamp>.
+// Uses the same directory and timestamp format as OpenPnP itself.
+// Returns the backup directory path.
+func Backup(configDir string) (string, error) {
+	stamp := time.Now().Format(timestampFmt)
+	dir := filepath.Join(configDir, backupSubdir, stamp)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating backup dir: %w", err)
+	}
+
+	copied := 0
+	for _, f := range backupFiles {
+		src := filepath.Join(configDir, f)
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			continue
+		}
+		if err := copyFile(src, filepath.Join(dir, f)); err != nil {
+			return "", fmt.Errorf("backing up %s: %w", f, err)
+		}
+		copied++
+	}
+	if copied == 0 {
+		_ = os.Remove(dir)
+		return "", fmt.Errorf("no config files found in %s", configDir)
+	}
+	return dir, nil
+}
+
+// CopyManagedFiles copies managed files from src to dst directory.
+// Returns the list of files actually copied.
+func CopyManagedFiles(srcDir, dstDir string) ([]string, error) {
+	var copied []string
+	for _, f := range ManagedFiles {
+		src := filepath.Join(srcDir, f)
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			continue
+		}
+		if err := copyFile(src, filepath.Join(dstDir, f)); err != nil {
+			return copied, fmt.Errorf("copying %s: %w", f, err)
+		}
+		copied = append(copied, f)
+	}
+	return copied, nil
+}
+
+// FileStatus describes the drift state of a single managed file.
+type FileStatus struct {
+	Name   string
+	Status string // "unchanged", "modified", "missing-live", "missing-repo"
+}
+
+// CompareFiles compares managed files between configDir (live) and repoDir.
+func CompareFiles(configDir, repoDir string) ([]FileStatus, error) {
+	var results []FileStatus
+	for _, f := range ManagedFiles {
+		live, liveErr := os.ReadFile(filepath.Join(configDir, f))
+		repo, repoErr := os.ReadFile(filepath.Join(repoDir, f))
+
+		var status string
+		switch {
+		case os.IsNotExist(liveErr) && os.IsNotExist(repoErr):
+			continue
+		case os.IsNotExist(liveErr):
+			status = "missing-live"
+		case os.IsNotExist(repoErr):
+			status = "missing-repo"
+		case liveErr != nil:
+			return nil, liveErr
+		case repoErr != nil:
+			return nil, repoErr
+		case string(live) == string(repo):
+			status = "unchanged"
+		default:
+			status = "modified"
+		}
+		results = append(results, FileStatus{Name: f, Status: status})
+	}
+	return results, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range ManagedFiles {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("<"+f+"/>"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestBackup(t *testing.T) {
+	dir := setupTestDir(t)
+
+	backupDir, err := Backup(dir)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+
+	for _, f := range ManagedFiles {
+		if _, err := os.Stat(filepath.Join(backupDir, f)); err != nil {
+			t.Errorf("missing backup file %s: %v", f, err)
+		}
+	}
+}
+
+func TestBackupIncludesExtraXMLs(t *testing.T) {
+	dir := setupTestDir(t)
+	// Add boards.xml and panels.xml like OpenPnP does
+	for _, f := range []string{"boards.xml", "panels.xml"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("<"+f+"/>"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	backupDir, err := Backup(dir)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+
+	for _, f := range backupFiles {
+		if _, err := os.Stat(filepath.Join(backupDir, f)); err != nil {
+			t.Errorf("missing backup file %s: %v", f, err)
+		}
+	}
+}
+
+func TestBackupNoFiles(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Backup(dir)
+	if err == nil {
+		t.Fatal("expected error for empty dir")
+	}
+}
+
+func TestCopyManagedFiles(t *testing.T) {
+	src := setupTestDir(t)
+	dst := t.TempDir()
+
+	copied, err := CopyManagedFiles(src, dst)
+	if err != nil {
+		t.Fatalf("CopyManagedFiles: %v", err)
+	}
+	if len(copied) != len(ManagedFiles) {
+		t.Errorf("copied %d files, want %d", len(copied), len(ManagedFiles))
+	}
+	for _, f := range ManagedFiles {
+		data, err := os.ReadFile(filepath.Join(dst, f))
+		if err != nil {
+			t.Errorf("missing %s in dst: %v", f, err)
+			continue
+		}
+		if string(data) != "<"+f+"/>" {
+			t.Errorf("%s content mismatch", f)
+		}
+	}
+}
+
+func TestCompareFiles(t *testing.T) {
+	live := setupTestDir(t)
+	repo := setupTestDir(t)
+
+	// Identical
+	results, err := CompareFiles(live, repo)
+	if err != nil {
+		t.Fatalf("CompareFiles: %v", err)
+	}
+	for _, r := range results {
+		if r.Status != "unchanged" {
+			t.Errorf("%s: got %s, want unchanged", r.Name, r.Status)
+		}
+	}
+
+	// Modify one file in live
+	if err := os.WriteFile(filepath.Join(live, "machine.xml"), []byte("<changed/>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	results, _ = CompareFiles(live, repo)
+	for _, r := range results {
+		if r.Name == "machine.xml" && r.Status != "modified" {
+			t.Errorf("machine.xml: got %s, want modified", r.Status)
+		}
+	}
+
+	// Remove from live
+	if err := os.Remove(filepath.Join(live, "parts.xml")); err != nil {
+		t.Fatal(err)
+	}
+	results, _ = CompareFiles(live, repo)
+	for _, r := range results {
+		if r.Name == "parts.xml" && r.Status != "missing-live" {
+			t.Errorf("parts.xml: got %s, want missing-live", r.Status)
+		}
+	}
+}

--- a/internal/openpnp/assign.go
+++ b/internal/openpnp/assign.go
@@ -21,7 +21,7 @@ type AssignResult struct {
 	FeederName string
 	PartID     string
 	OldPartID  string
-	Status     string // "assigned", "unchanged", "not_found"
+	Status     string // StatusAssigned, StatusUnchanged, StatusNotFound
 }
 
 // AssignFeeders updates feeder attributes in machine.xml.
@@ -51,7 +51,7 @@ func AssignFeeders(
 			results = append(results, AssignResult{
 				FeederName: a.FeederName,
 				PartID:     a.PartID,
-				Status:     "not_found",
+				Status:     StatusNotFound,
 			})
 			continue
 		}
@@ -70,9 +70,9 @@ func AssignFeeders(
 		pkg := PackageFromPartID(a.PartID, pkgMap)
 		applyPackageMetadata(&content, a.FeederName, pkg, pkgMap, stripLength)
 
-		status := "unchanged"
+		status := StatusUnchanged
 		if changed {
-			status = "assigned"
+			status = StatusAssigned
 		}
 		results = append(results, AssignResult{
 			FeederName: a.FeederName,
@@ -141,7 +141,7 @@ func resetUnassignedFeeders(
 				FeederName: feederName,
 				PartID:     dummyPartID,
 				OldPartID:  oldPartID,
-				Status:     "reset",
+				Status:     StatusReset,
 			})
 		}
 

--- a/internal/openpnp/reset.go
+++ b/internal/openpnp/reset.go
@@ -8,11 +8,19 @@ import (
 	"strings"
 )
 
+// Status constants for feeder operations.
+const (
+	StatusReset     = "reset"
+	StatusUnchanged = "unchanged"
+	StatusAssigned  = "assigned"
+	StatusNotFound  = "not_found"
+)
+
 // ResetResult reports what happened for each feeder.
 type ResetResult struct {
 	FeederName string
 	OldPartID  string
-	Status     string // "reset", "unchanged"
+	Status     string // StatusReset, StatusUnchanged
 }
 
 // ResetFeeders sets all feeder part-ids to dummyPartID and resets feed-count to 0.
@@ -81,10 +89,10 @@ func ResetFeeders(machinePath string, dummyPartID string) ([]ResetResult, error)
 		oldPartID2 := content[partStart : partStart+partEnd]
 		_ = oldPartID2
 
-		status := "unchanged"
+		status := StatusUnchanged
 		if oldPartID != dummyPartID {
 			content = content[:partStart] + dummyPartID + content[partStart+partEnd:]
-			status = "reset"
+			status = StatusReset
 		}
 
 		results = append(results, ResetResult{


### PR DESCRIPTION
Adds `openpnp-tools config` subcommand group for managing the base config workflow:

- `config backup` — snapshot ~/.openpnp2 (same format as OpenPnP's own backups)
- `config apply` — backup + copy base config → ~/.openpnp2
- `config pull` — copy live config → repo + reset feeders
- `config status` — OpenPnP process check + per-file drift report

Also extracts feeder status string constants (fixes goconst lint).

Closes #5, closes #6, closes #7, closes #8